### PR TITLE
fix 'clam_sb' and 'clam_mb' models in val_loop and test functions

### DIFF
--- a/main.py
+++ b/main.py
@@ -638,6 +638,8 @@ def val_loop(args,model,loader,device,criterion,early_stopping,epoch,model_tea=N
                     test_logits = test_logits[0]
             elif args.model == 'dsmil':
                 test_logits,_ = model(bag)
+            elif args.model in ('clam_sb','clam_mb'):
+                test_logits,_,_ = model(bag,label=label)
             else:
                 test_logits = model(bag)
 
@@ -703,6 +705,8 @@ def test(args,model,loader,device,criterion,model_tea=None,opt_thr=None):
                     test_logits = test_logits[0]
             elif args.model == 'dsmil':
                 test_logits,_ = model(bag)
+            elif args.model in ('clam_sb','clam_mb'):
+                test_logits,_,_ = model(bag,label=label)
             else:
                 test_logits = model(bag)
 


### PR DESCRIPTION
clam的forward中需要给label赋值，否则会在clam.py中的183行inst_labels = F.one_hot(label, num_classes=self.n_classes).squeeze() #binarize label报错